### PR TITLE
Adds control centre page for survey themes manager

### DIFF
--- a/config.json
+++ b/config.json
@@ -150,5 +150,15 @@
             "repeatable": true
         }
     ],
+    "links": {
+      "control-center": [
+        {
+          "name": "Manage Survey Themes",
+          "icon": "fas fa-palette",
+          "url": "manage_global_themes.php",
+          "show-header-and-footer": false
+        }
+      ]
+    },
     "project-settings": [ ]
 }


### PR DESCRIPTION
This PR should enable admins to navigate directly to the global survey theme editor page without having to navigate into modules, configure, and click the link. 
<img width="361" alt="image" src="https://github.com/user-attachments/assets/831a5c26-37b5-4402-b847-1c06e178c00a">
